### PR TITLE
Made it possible to let the image on a card empty

### DIFF
--- a/src/ContentBlocks/CardsBlock.php
+++ b/src/ContentBlocks/CardsBlock.php
@@ -140,8 +140,8 @@ class CardsBlock extends AbstractFilamentFlexibleContentBlock
         foreach ($cardsBlockData as $card) {
             $cardData[] = CardData::create(
                 cardBlockData: $card,
-                imageUrl: $this->getCardImageUrl($card['image']),
-                imageHtml: $this->getCardImageMedia($card['image'], $card['title']),
+                imageUrl: $card['image'] ? $this->getCardImageUrl($card['image']) : null,
+                imageHtml: $card['image'] ? $this->getCardImageMedia($card['image'], $card['title']) : null,
                 blockStyle: $this->hasDefaultBlockStyle() ? null : $this->blockStyle,
                 buttonStyleClasses: CallToActionField::getButtonStyleClasses(static::class)
             );


### PR DESCRIPTION
Since image is not required on a card block, made it possible to leave it empty.
This way you can generate a card view without an image but just a background