### PR TITLE
Fix: HasSlugAttributeTrait referenced `$this` when in a static context

### DIFF
--- a/src/Models/Concerns/HasSlugAttributeTrait.php
+++ b/src/Models/Concerns/HasSlugAttributeTrait.php
@@ -35,12 +35,12 @@ trait HasSlugAttributeTrait
 
             if (! empty($changedSlugs)) {
                 $published = true;
-                if (method_exists($this, 'isPublishedForDates')) {
-                    $published = $this->isPublishedForDates($this->getOriginal('publishing_begins_at'), $this->getOriginal('publishing_ends_at'));
+                if (method_exists($record, 'isPublishedForDates')) {
+                    $published = $record->isPublishedForDates($record->getOriginal('publishing_begins_at'), $record->getOriginal('publishing_ends_at'));
                 }
 
                 //dispatch event:
-                SlugChanged::dispatch($this, $changedSlugs, $published);
+                SlugChanged::dispatch($record, $changedSlugs, $published);
             }
         });
     }


### PR DESCRIPTION
Changed it to `$record` instead as is done in the `HasTranslatableSlugAttributeTrait`.