### PR TITLE
Fix: Initialize properties to null in Hero component class

### DIFF
--- a/src/Models/Concerns/HasSlugAttributeTrait.php
+++ b/src/Models/Concerns/HasSlugAttributeTrait.php
@@ -35,12 +35,12 @@ trait HasSlugAttributeTrait
 
             if (! empty($changedSlugs)) {
                 $published = true;
-                if (method_exists($this, 'isPublishedForDates')) {
-                    $published = $this->isPublishedForDates($this->getOriginal('publishing_begins_at'), $this->getOriginal('publishing_ends_at'));
+                if (method_exists($record, 'isPublishedForDates')) {
+                    $published = $record->isPublishedForDates($record->getOriginal('publishing_begins_at'), $record->getOriginal('publishing_ends_at'));
                 }
 
                 //dispatch event:
-                SlugChanged::dispatch($this, $changedSlugs, $published);
+                SlugChanged::dispatch($record, $changedSlugs, $published);
             }
         });
     }

--- a/src/View/Components/Hero.php
+++ b/src/View/Components/Hero.php
@@ -17,9 +17,9 @@ class Hero extends Component
 
     public ?string $intro = null;
 
-    public ?string $heroImageTitle;
+    public ?string $heroImageTitle = null;
 
-    public ?string $heroImageCopyright;
+    public ?string $heroImageCopyright = null;
 
     public function __construct(HasPageAttributes|HasHeroImageAttributes|HasIntroAttribute $page)
     {


### PR DESCRIPTION
Set the properties of the Hero component to null by default, this prevents the following error from being thrown if any of the provided props are not set.

```
Typed property Statikbe\FilamentFlexibleContentBlocks\View\Components\Hero::$heroImageCopyright must not be accessed before initialization
```

Basically this allows the hero image to be not set without breaking the page.