### PR TITLE
First check if type isset on blockData

### DIFF
--- a/src/View/Components/ContentBlocks.php
+++ b/src/View/Components/ContentBlocks.php
@@ -31,7 +31,7 @@ class ContentBlocks extends Component
         $blocks = [];
 
         foreach ($page->content_blocks as $blockData) {
-            if ($blockClassIndex->has($blockData['type'])) {
+            if (isset($blockData['type']) && $blockClassIndex->has($blockData['type'])) {
                 $blockClass = $blockClassIndex->get($blockData['type']);
                 $blocks[] = new $blockClass($page, $blockData['data']);
             }


### PR DESCRIPTION
### Description

When all content is delete on a page, the ckeck `$blockClassIndex->has($blockData['type'])`
crashed because `type`is not set.

### Reason for this change

![image](https://github.com/statikbe/laravel-filament-flexible-content-blocks/assets/5928907/3e055ecb-b3e0-4a10-9a9c-c6b48377d529)
