### PR TITLE
Replace SEO description filed from RichText to Textarea

### DIFF
--- a/src/Filament/Form/Fields/SEODescriptionField.php
+++ b/src/Filament/Form/Fields/SEODescriptionField.php
@@ -2,8 +2,28 @@
 
 namespace Statikbe\FilamentFlexibleContentBlocks\Filament\Form\Fields;
 
-class SEODescriptionField extends DescriptionField
+use Filament\Forms\Components\Textarea;
+use Statikbe\FilamentFlexibleContentBlocks\Filament\Form\Fields\Concerns\HasTranslatableHint;
+
+use function trans;
+
+class SEODescriptionField extends Textarea
 {
+    use HasTranslatableHint;
+
+    public static function create(bool $required = false): static
+    {
+        $field = static::getFieldName();
+
+        return static::make($field)
+            ->label(
+                trans("filament-flexible-content-blocks::filament-flexible-content-blocks.form_component.{$field}_lbl")
+            )
+            ->rows(3)
+            ->required($required)
+            ->addsTranslatableHint();
+    }
+
     public static function getFieldName(): string
     {
         return 'seo_description';

--- a/src/Models/Concerns/HasSEOAttributesTrait.php
+++ b/src/Models/Concerns/HasSEOAttributesTrait.php
@@ -3,6 +3,7 @@
 namespace Statikbe\FilamentFlexibleContentBlocks\Models\Concerns;
 
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Str;
 use Spatie\Image\Enums\Fit;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -46,10 +47,10 @@ trait HasSEOAttributesTrait
     public function getSEODescription(): ?string
     {
         if (! $this->seo_description && isset($this->intro)) {
-            return $this->intro;
+            return Str::squish(strip_tags($this->intro));
         }
 
-        return $this->seo_description;
+        return Str::squish($this->seo_description);
     }
 
     protected function registerSEOImageMediaCollectionAndConversion()


### PR DESCRIPTION
### Description
Replace SEO filed type from `RichEditor ` to `Textarea`

### Reason for this change

Field was `Richeditor` and it saved to DB data with html tags. 
As soon as someone calls `getSEODescription` script returns string with tags.
On my personal opinion meta description it does not need any html tags as should be plain text.