### PR TITLE
Added slug on first title save for new languages

### DIFF
--- a/src/Filament/Form/Fields/SlugField.php
+++ b/src/Filament/Form/Fields/SlugField.php
@@ -37,7 +37,20 @@ class SlugField extends TextInput
             //make the slug required on edit. on create, the slug is not required so if kept blank a slug is generated.
             ->required(fn (?Model $record): bool => $record && $record->id > 0)
             //hide slug field on creation, because the spatie sluggable will overwrite it anyways:
-            ->hidden(fn (?Model $record): bool => is_null($record))
+            ->hidden(function (?Model $record, Page $livewire): bool {
+                if (empty($record)) {
+                    return true;
+                }
+
+                if (isset($record->translatable) && in_array(static::FIELD, $record->translatable)) {
+                    if (method_exists($livewire, 'getActiveFormsLocale')) {
+                        $locale = $livewire->getActiveFormsLocale();
+                        return empty($record->getTranslation(static::FIELD, $locale, false));
+                    }
+                }
+
+                return false;
+            })
             ->addsTranslatableHint();
     }
 

--- a/src/Filament/Form/Fields/TitleField.php
+++ b/src/Filament/Form/Fields/TitleField.php
@@ -16,6 +16,7 @@ class TitleField extends TextInput
         return static::make($field)
             ->label(trans("filament-flexible-content-blocks::filament-flexible-content-blocks.form_component.{$field}_lbl"))
             ->maxLength(255)
+            ->live()
             ->addsTranslatableHint()
             ->required($required);
     }

--- a/src/Models/Concerns/HasTranslatedSlugAttributeTrait.php
+++ b/src/Models/Concerns/HasTranslatedSlugAttributeTrait.php
@@ -19,6 +19,11 @@ trait HasTranslatedSlugAttributeTrait
         $this->mergeTranslatable(['slug']);
     }
 
+    public function addParentSlug(){
+        $this->slugOptions = $this->getSlugOptions();
+        $this->addSlug();
+    }
+
     protected static function bootHasTranslatedSlugAttributeTrait(): void
     {
         //dispatch event when slug changes for published models:
@@ -41,6 +46,12 @@ trait HasTranslatedSlugAttributeTrait
                     ];
                 }
             }
+
+            /* Update slugs. If slug was empty before */
+            $oldTranslations = $record->getTranslations('slug');
+            $record->addParentSlug();
+            $newTranslations = $record->getTranslations('slug');
+            $record->setTranslations('slug', array_merge($newTranslations, $oldTranslations));
 
             if (! empty($changedSlugs)) {
                 $published = true;


### PR DESCRIPTION
### Description
Allow to generate automatically slug for languages added later 

### Reason for this change
E.g I have 3 languages. I created and saved a page for 1st language only.  A little bit later prepared content and adding Title and other information for second language.
As a result I need to type manually slug. I ma not sure there is any validation for unique one. Also I could insert slug as "simple text" and nothing formatted it to slug format. So I decided to implement first slug generation like during creating new  record. 