### PR TITLE
Update VideoBlock.php

### DIFF
--- a/src/ContentBlocks/VideoBlock.php
+++ b/src/ContentBlocks/VideoBlock.php
@@ -109,6 +109,6 @@ class VideoBlock extends AbstractFilamentFlexibleContentBlock
 
     public function hasOverlayImage(): bool
     {
-        return $this->hasMedia($this->getBlockId());
+        return $this->hasImage($this->getBlockId());
     }
 }


### PR DESCRIPTION
The method hasMedia does not exist - replaced with hasImage and tested to return true or false.

### Description

Checking with hasMedia returns an error:
Call to undefined method Statikbe\FilamentFlexibleContentBlocks\ContentBlocks\VideoBlock::hasMedia()

Replacing this function with hasImage fixes this issue and returns true or false if a placeholder is attached to the video content.

### Reason for this change

Bugfix.