### PR TITLE
Fix scope `published` to return correct published posts

### DIFF
--- a/src/Models/Concerns/HasPageAttributesTrait.php
+++ b/src/Models/Concerns/HasPageAttributesTrait.php
@@ -106,7 +106,7 @@ trait HasPageAttributesTrait
         $publishedQuery->orWhere(function (Builder $option1) {
             $option1->whereNull('publishing_begins_at')
                 ->whereNotNull('publishing_ends_at')
-                ->where('publishing_ends_at', '>', 'now()');
+                ->whereRaw('publishing_ends_at > now()');
         })->orWhere(function (Builder $option2) {
             $option2->whereNotNull('publishing_begins_at')
                 ->whereNotNull('publishing_ends_at')


### PR DESCRIPTION
### Description
In method `createPublishedSubquery` was wrong `where` state.

### Reason for this change

Instead of using SQL function `now()`, was string `now()`.
A little bit lower there is the correct `where` with calling SQL function instead of string

@sten 