### PR TITLE
Make sure parent is correctly saved on page

### DIFF
--- a/config/filament-flexible-content-blocks.php
+++ b/config/filament-flexible-content-blocks.php
@@ -161,7 +161,7 @@ return [
     | List the models that can be used to add items from in the overview block.
     */
     'overview_models' => [
-        //e.g. 'App\Models\FlexiblePage',
+        // e.g. 'App\Models\FlexiblePage',
     ],
 
     /*
@@ -174,8 +174,8 @@ return [
     | to which you can respectively add the model and its the custom CTA type implementation.
     */
     'call_to_action_models' => [
-        //e.g. 'App\Models\FlexiblePage',
-        //Or if you want to implement a custom CTA type, e.g. for the asset manager see https://github.com/statikbe/laravel-filament-flexible-blocks-asset-manager:
+        // e.g. 'App\Models\FlexiblePage',
+        // Or if you want to implement a custom CTA type, e.g. for the asset manager see https://github.com/statikbe/laravel-filament-flexible-blocks-asset-manager:
         /*[
             'model' => \Statikbe\FilamentFlexibleBlocksAssetManager\Models\Asset::class,
             'call_to_action_type' => \Statikbe\FilamentFlexibleBlocksAssetManager\Filament\Form\Fields\Blocks\Type\AssetCallToActionType::class,

--- a/example/app/Models/Page.php
+++ b/example/app/Models/Page.php
@@ -36,7 +36,7 @@ class Page extends Model implements HasContentBlocks, HasHeroImageAttributes, Ha
 
     public function getViewUrl(?string $locale = null): string
     {
-        //todo implement controller and add route:
+        // todo implement controller and add route:
         return config('app.url');
     }
 

--- a/example/app/Models/TranslatablePage.php
+++ b/example/app/Models/TranslatablePage.php
@@ -41,7 +41,7 @@ class TranslatablePage extends Model implements HasCode, HasContentBlocks, HasHe
 
     public function getViewUrl(?string $locale = null): string
     {
-        //todo implement controller and add route:
+        // todo implement controller and add route:
         return config('app.url');
     }
 

--- a/example/database/migrations/create_default_pages_table.php
+++ b/example/database/migrations/create_default_pages_table.php
@@ -13,40 +13,40 @@ return new class extends Migration
 
             $table->string('title');
 
-            //Intro:
+            // Intro:
             $table->text('intro')->nullable();
 
-            //Hero image:
+            // Hero image:
             $table->string('hero_image_copyright')->nullable();
             $table->string('hero_image_title')->nullable();
 
-            //Publishing:
+            // Publishing:
             $table->timestamp('publishing_begins_at')->nullable();
             $table->timestamp('publishing_ends_at')->nullable();
             $table->index('publishing_begins_at');
             $table->index('publishing_ends_at');
 
-            //SEO:
+            // SEO:
             $table->string('seo_title')->nullable();
             $table->text('seo_description')->nullable();
             $table->json('seo_keywords')->nullable();
 
-            //Overview:
+            // Overview:
             $table->string('overview_title')->nullable();
             $table->text('overview_description')->nullable();
 
-            //Content blocks:
-            $table->json('content_blocks')->default('[]'); //Default only works on JSON on MySQL 8 or newer
+            // Content blocks:
+            $table->json('content_blocks')->default('[]'); // Default only works on JSON on MySQL 8 or newer
 
-            //Slug:
+            // Slug:
             $table->string('slug');
 
-            //Author:
+            // Author:
             $table->unsignedBigInteger('author_id')->nullable();
             $table->foreign('author_id')
                 ->references('id')->on('users')->onDelete('set null');
 
-            //Parent-child:
+            // Parent-child:
             $table->unsignedBigInteger('parent_id')->nullable();
             $table->foreign('parent_id')->references('id')->on('pages');
 

--- a/example/database/migrations/create_default_translatable_pages_table.php
+++ b/example/database/migrations/create_default_translatable_pages_table.php
@@ -11,45 +11,45 @@ return new class extends Migration
         Schema::create('translatable_pages', function (Blueprint $table) {
             $table->id();
 
-            $table->json('title')->default('{}'); //Default only works on JSON on MySQL 8 or newer
+            $table->json('title')->default('{}'); // Default only works on JSON on MySQL 8 or newer
 
-            //Intro:
+            // Intro:
             $table->json('intro')->default('{}');
 
-            //Hero image:
+            // Hero image:
             $table->json('hero_image_copyright')->default('{}');
             $table->json('hero_image_title')->default('{}');
 
-            //Publishing:
+            // Publishing:
             $table->timestamp('publishing_begins_at')->nullable();
             $table->timestamp('publishing_ends_at')->nullable();
             $table->index('publishing_begins_at');
             $table->index('publishing_ends_at');
 
-            //SEO:
+            // SEO:
             $table->json('seo_title')->nullable();
             $table->json('seo_description')->nullable();
             $table->json('seo_keywords')->nullable();
 
-            //Overview:
+            // Overview:
             $table->json('overview_title')->nullable();
             $table->json('overview_description')->nullable();
 
-            //Content blocks:
-            $table->json('content_blocks')->default('[]'); //Default only works on JSON on MySQL 8 or newer
+            // Content blocks:
+            $table->json('content_blocks')->default('[]'); // Default only works on JSON on MySQL 8 or newer
 
-            //Slug:
+            // Slug:
             $table->json('slug')->default('{}');
 
-            //Unique code:
+            // Unique code:
             $table->string('code')->nullable()->unique();
 
-            //Author:
+            // Author:
             $table->unsignedBigInteger('author_id')->nullable();
             $table->foreign('author_id')
                 ->references('id')->on('users')->onDelete('set null');
 
-            //Parent-child:
+            // Parent-child:
             $table->unsignedBigInteger('parent_id')->nullable();
             $table->foreign('parent_id')->references('id')->on('pages');
 

--- a/src/Commands/UpgradeSpatieImageFieldsCommand.php
+++ b/src/Commands/UpgradeSpatieImageFieldsCommand.php
@@ -50,7 +50,7 @@ class UpgradeSpatieImageFieldsCommand extends Command implements PromptsForMissi
         $model::orderBy('id', 'desc')->chunk(50, function (Collection $models) {
             foreach ($models as $model) {
                 /* @var HasContentBlocks $model */
-                //check if the model is translated:
+                // check if the model is translated:
                 if (isset($model->translatable) && in_array('content_blocks', $model->translatable)) {
                     foreach (FilamentFlexibleContentBlocks::getLocales() as $locale) {
                         $contentBlocks = $model->getTranslation('content_blocks', $locale);
@@ -62,7 +62,7 @@ class UpgradeSpatieImageFieldsCommand extends Command implements PromptsForMissi
                 } else {
                     $model->content_blocks = $this->upgradeContentBlocks($model->content_blocks, $model);
 
-                    //save upgrade
+                    // save upgrade
                     $model->save();
                 }
 
@@ -79,7 +79,7 @@ class UpgradeSpatieImageFieldsCommand extends Command implements PromptsForMissi
     public function upgradeContentBlocks(array $contentBlocks, Model $model): array
     {
         foreach ($contentBlocks as &$block) {
-            //add block id to each block:
+            // add block id to each block:
             if (! isset($block['data'][BlockIdField::FIELD])) {
                 $block['data'][BlockIdField::FIELD] = BlockIdField::generateBlockId();
             }
@@ -90,7 +90,7 @@ class UpgradeSpatieImageFieldsCommand extends Command implements PromptsForMissi
                 }
             }
 
-            //cards:
+            // cards:
             if ($block['type'] === 'filament-flexible-content-blocks::cards') {
                 if (isset($block['data']['cards'])) {
                     foreach ($block['data']['cards'] as $card) {
@@ -116,13 +116,13 @@ class UpgradeSpatieImageFieldsCommand extends Command implements PromptsForMissi
             /* @var Media $media */
             $media = Media::findByUuid($mediaUuid);
             if ($media) {
-                //Check if there is already a block assigned. If so, this means it is already used by another block.
-                //This is possible because of the old copy content blocks button to other locales, that did not copy media for each locale.
+                // Check if there is already a block assigned. If so, this means it is already used by another block.
+                // This is possible because of the old copy content blocks button to other locales, that did not copy media for each locale.
                 if ($media->getCustomProperty('block')) {
-                    //make a copy of the media:
+                    // make a copy of the media:
                     $media = $media->copy($model, $media->collection_name, $media->disk);
                 }
-                //add block id as custom property to media:
+                // add block id as custom property to media:
                 $media->setCustomProperty('block', $blockId);
                 $media->save();
 

--- a/src/ContentBlocks/AbstractContentBlock.php
+++ b/src/ContentBlocks/AbstractContentBlock.php
@@ -37,9 +37,9 @@ abstract class AbstractContentBlock extends Component
         $this->record = $record;
         $this->blockData = $blockData;
 
-        //block id:
+        // block id:
         if (! isset($this->blockData[BlockIdField::FIELD]) || ! $this->blockData[BlockIdField::FIELD]) {
-            //initialise the ID for a new block, then never change it.
+            // initialise the ID for a new block, then never change it.
             $this->blockData[BlockIdField::FIELD] = BlockIdField::generateBlockId();
         }
 
@@ -85,7 +85,7 @@ abstract class AbstractContentBlock extends Component
     {
         return function (\Filament\Forms\Components\Component $component) {
             return array_merge([
-                //keep track of block id:
+                // keep track of block id:
                 BlockIdField::create(),
             ],
                 $component->evaluate(static::makeFilamentSchema()));
@@ -111,7 +111,7 @@ abstract class AbstractContentBlock extends Component
      */
     public static function addMediaCollectionAndConversion(HasMedia&HasMediaAttributes $record): void
     {
-        //overwrite to add collection and conversion here if the block has images
+        // overwrite to add collection and conversion here if the block has images
     }
 
     /**

--- a/src/ContentBlocks/CallToActionBlock.php
+++ b/src/ContentBlocks/CallToActionBlock.php
@@ -116,7 +116,7 @@ class CallToActionBlock extends AbstractFilamentFlexibleContentBlock
                     ->format(ImageFormat::WEBP->value);
                 FilamentFlexibleBlocksConfig::mergeConfiguredFlexibleBlockImageConversion(static::class, static::getName(), static::CONVERSION_DEFAULT, $conversion);
 
-                //for filament upload field
+                // for filament upload field
                 $record->addFilamentThumbnailMediaConversion();
             });
     }

--- a/src/ContentBlocks/CardsBlock.php
+++ b/src/ContentBlocks/CardsBlock.php
@@ -114,7 +114,7 @@ class CardsBlock extends AbstractFilamentFlexibleContentBlock
                 static::addCropImageConversion($record, 800, 420);
                 static::addContainImageConversion($record, 800, 420);
 
-                //for filament upload field
+                // for filament upload field
                 $record->addFilamentThumbnailMediaConversion();
             });
     }

--- a/src/ContentBlocks/Concerns/HasBlockStyle.php
+++ b/src/ContentBlocks/Concerns/HasBlockStyle.php
@@ -6,7 +6,7 @@ use Statikbe\FilamentFlexibleContentBlocks\Filament\Form\Fields\Blocks\BlockStyl
 
 trait HasBlockStyle
 {
-    //we need to use a static string instead of a const, because PHP8.1 is lacking const in traits:
+    // we need to use a static string instead of a const, because PHP8.1 is lacking const in traits:
     public static string $DEFAULT_BLOCK_STYLE = 'default';
 
     public ?string $blockStyle;

--- a/src/ContentBlocks/Concerns/HasCallToAction.php
+++ b/src/ContentBlocks/Concerns/HasCallToAction.php
@@ -76,7 +76,7 @@ trait HasCallToAction
                 try {
                     $data[] = CallToActionData::create($callToAction, CallToActionField::getButtonStyleClasses(static::class));
                 } catch (CallToActionNotDefinedException $ex) {
-                    //do not include the data if nothing is specified.
+                    // do not include the data if nothing is specified.
                 } catch (LinkableModelNotFoundException $ex) {
                     $ex->setRecord($this->record);
                     throw $ex;

--- a/src/ContentBlocks/ImageBlock.php
+++ b/src/ContentBlocks/ImageBlock.php
@@ -99,14 +99,14 @@ class ImageBlock extends AbstractFilamentFlexibleContentBlock
                 static::addCropImageConversion($record, 1200, 630);
                 static::addContainImageConversion($record, 1200, 630);
 
-                //for filament upload field
+                // for filament upload field
                 $record->addFilamentThumbnailMediaConversion();
             });
     }
 
     public static function getImageConversionTypeDefault(): string
     {
-        //change the default image conversion for the image block to show the real aspect ratio.
+        // change the default image conversion for the image block to show the real aspect ratio.
         return static::CONVERSION_CONTAIN;
     }
 

--- a/src/ContentBlocks/TemplateBlock.php
+++ b/src/ContentBlocks/TemplateBlock.php
@@ -42,7 +42,7 @@ class TemplateBlock extends AbstractFilamentFlexibleContentBlock
 
     public static function visible(): bool|Closure
     {
-        //only show block when templates are set in the config:
+        // only show block when templates are set in the config:
         return ! empty(FilamentFlexibleBlocksConfig::getTemplatesConfig(static::class));
     }
 }

--- a/src/ContentBlocks/TextImageBlock.php
+++ b/src/ContentBlocks/TextImageBlock.php
@@ -123,7 +123,7 @@ class TextImageBlock extends AbstractFilamentFlexibleContentBlock
                 static::addCropImageConversion($record, 1200, 630);
                 static::addContainImageConversion($record, 1200, 630);
 
-                //for filament upload field
+                // for filament upload field
                 $record->addFilamentThumbnailMediaConversion();
             });
     }

--- a/src/ContentBlocks/VideoBlock.php
+++ b/src/ContentBlocks/VideoBlock.php
@@ -92,7 +92,7 @@ class VideoBlock extends AbstractFilamentFlexibleContentBlock
             ->registerMediaConversions(function (Media $media) use ($record) {
                 static::addCropImageConversion($record, 1200, 675);
 
-                //for filament upload field
+                // for filament upload field
                 $record->addFilamentThumbnailMediaConversion();
             });
     }

--- a/src/Filament/Actions/CopyContentBlocksToLocalesActionHandler.php
+++ b/src/Filament/Actions/CopyContentBlocksToLocalesActionHandler.php
@@ -21,7 +21,7 @@ class CopyContentBlocksToLocalesActionHandler
     public function handle(Model&HasMedia $record, Component $livewire, ?array $contentBlocks): void
     {
         if ($contentBlocks) {
-            //check if the LocaleSwitch action is implemented:
+            // check if the LocaleSwitch action is implemented:
             if (! method_exists($livewire, 'getActiveFormsLocale')) {
                 Notification::make()
                     ->title(trans('filament-flexible-content-blocks::filament-flexible-content-blocks.form_component.copy_content_blocks_to_other_locales.error_resource_not_translatable'))
@@ -41,16 +41,16 @@ class CopyContentBlocksToLocalesActionHandler
             }
 
             try {
-                //get other locales than the current one.
+                // get other locales than the current one.
                 $currentLocale = $livewire->getActiveFormsLocale();
                 $otherLocales = collect(FilamentFlexibleContentBlocks::getLocales())->diff([$currentLocale]);
 
                 DB::beginTransaction();
-                //copy content blocks
+                // copy content blocks
                 foreach ($otherLocales as $otherLocale) {
                     $convertedContentBlocks = $this->convertContentBlockIdAndImages($record, $contentBlocks, $otherLocale);
                     $record->setTranslation(ContentBlocksField::FIELD, $otherLocale, $convertedContentBlocks);
-                    //update form data:
+                    // update form data:
                     $livewire->otherLocaleData[$otherLocale][ContentBlocksField::FIELD] = $convertedContentBlocks;
                 }
 
@@ -64,7 +64,7 @@ class CopyContentBlocksToLocalesActionHandler
                     ->success()
                     ->send();
 
-                //reload page to see the changes:
+                // reload page to see the changes:
                 redirect(request()->header('Referer'));
             } catch (\Exception $exception) {
                 Log::error($exception);
@@ -95,13 +95,13 @@ class CopyContentBlocksToLocalesActionHandler
             $dataBlock = &$contentBlock['data'];
         }
 
-        //generate new block id:
+        // generate new block id:
         if (isset($dataBlock[BlockIdField::FIELD]) && $dataBlock[BlockIdField::FIELD]) {
             $oldBlockId = $dataBlock[BlockIdField::FIELD];
             $newBlockId = BlockIdField::generateBlockId();
             $dataBlock[BlockIdField::FIELD] = $newBlockId;
 
-            //copy media to new block:
+            // copy media to new block:
             $oldBlockMedia = $record->getMedia('*', ['block' => $oldBlockId]);
             foreach ($oldBlockMedia as $oldBlockMediaItem) {
                 $this->copyImage($record, $oldBlockMediaItem, $newBlockId);
@@ -121,7 +121,7 @@ class CopyContentBlocksToLocalesActionHandler
     {
         $copiedImage = $oldMediaItem->copy($record, $oldMediaItem->collection_name, $oldMediaItem->disk);
 
-        //set block ID:
+        // set block ID:
         if ($blockId) {
             $copiedImage->setCustomProperty('block', $blockId);
             $copiedImage->save();

--- a/src/Filament/Form/Fields/AuthorField.php
+++ b/src/Filament/Form/Fields/AuthorField.php
@@ -18,7 +18,7 @@ class AuthorField extends Select
             ->relationship('author', 'name')
             ->default(Auth::user()->id)
             ->searchable()
-            //this is a default search query, add your own implementation by implementing getSearchResultsUsing on creation of the field.
+            // this is a default search query, add your own implementation by implementing getSearchResultsUsing on creation of the field.
             ->getSearchResultsUsing(function (string $searchQuery) {
                 $searchQuery = trim(Str::lower($searchQuery));
 

--- a/src/Filament/Form/Fields/Blocks/BlockSpatieMediaLibraryFileUpload.php
+++ b/src/Filament/Form/Fields/Blocks/BlockSpatieMediaLibraryFileUpload.php
@@ -44,10 +44,10 @@ class BlockSpatieMediaLibraryFileUpload extends SpatieMediaLibraryFileUpload
 
     public function getState(): mixed
     {
-        //if the language switch is used, the form data needs to reset with a UUID in an array.
-        //often a string UUID is returned by getState() so this function is overwritten to wrap string UUIDs in an array:
+        // if the language switch is used, the form data needs to reset with a UUID in an array.
+        // often a string UUID is returned by getState() so this function is overwritten to wrap string UUIDs in an array:
         $state = parent::getState();
-        //transform strings to arrays since the upload field expects an array of UUIDs:
+        // transform strings to arrays since the upload field expects an array of UUIDs:
         if ($state && ! is_array($state)) {
             $state = array_filter([$state]);
         }
@@ -73,9 +73,9 @@ class BlockSpatieMediaLibraryFileUpload extends SpatieMediaLibraryFileUpload
             $rules[] = "min:{$count}";
         }
 
-        //Changed to support the language switch
+        // Changed to support the language switch
         $rules[] = function (string $attribute, array|string|TemporaryUploadedFile $value, Closure $fail): void {
-            //Changed: Transform $value to array
+            // Changed: Transform $value to array
             if (is_string($value) || $value instanceof TemporaryUploadedFile) {
                 $value = [$value];
             }
@@ -88,7 +88,7 @@ class BlockSpatieMediaLibraryFileUpload extends SpatieMediaLibraryFileUpload
 
             $validator = Validator::make(
                 [$name => $files],
-                ["{$name}.*" => ['file', ...$this->getValidationRulesTrait()]], //Changed to load validation rules of trait (see on top of class) instead of the rules from BaseFileUpload.
+                ["{$name}.*" => ['file', ...$this->getValidationRulesTrait()]], // Changed to load validation rules of trait (see on top of class) instead of the rules from BaseFileUpload.
                 $validationMessages ? ["{$name}.*" => $validationMessages] : [],
                 ["{$name}.*" => $this->getValidationAttribute()],
             );

--- a/src/Filament/Form/Fields/Blocks/BlockStyleField.php
+++ b/src/Filament/Form/Fields/Blocks/BlockStyleField.php
@@ -20,7 +20,7 @@ class BlockStyleField extends Select
             ->helperText(trans('filament-flexible-content-blocks::filament-flexible-content-blocks.form_component.block_style_help'))
             ->options(FilamentFlexibleBlocksConfig::getBlockStyleSelectOptions($blockClass))
             ->default(FilamentFlexibleBlocksConfig::getBlockStyleDefault($blockClass))
-            //only show when enabled and when there are styles configured:
+            // only show when enabled and when there are styles configured:
             ->visible($blockClass::hasBlockStyles() && count(FilamentFlexibleBlocksConfig::getBlockStyleSelectOptions($blockClass)) > 1)
             ->selectablePlaceholder(false)
             ->required($required);

--- a/src/Filament/Form/Fields/Blocks/CallToActionField.php
+++ b/src/Filament/Form/Fields/Blocks/CallToActionField.php
@@ -108,7 +108,7 @@ class CallToActionField extends Component
                     Select::make(static::FIELD_ENTRY_ID)
                         ->columnSpan(4)
                         ->label(function (Get $get) use ($types) {
-                            //get the selected type:
+                            // get the selected type:
                             $selectedTypeModel = $get(static::FIELD_CTA_MODEL);
                             $selectedType = collect($types)->filter(fn (CallToActionType $type) => ! $type->isUrlType() && ! $type->isRouteType() && $type->getModel() === $selectedTypeModel)->first();
 

--- a/src/Filament/Form/Fields/Blocks/Data/CallToActionData.php
+++ b/src/Filament/Form/Fields/Blocks/Data/CallToActionData.php
@@ -54,7 +54,7 @@ class CallToActionData
                 $page = $linkableModel::findOrFail($callToActionBlockData[CallToActionField::FIELD_ENTRY_ID]);
                 $url = $page->getViewUrl();
             } catch (ModelNotFoundException $ex) {
-                //The url could not be created because the entry could not be found. By catching the exception, we avoid a 404.
+                // The url could not be created because the entry could not be found. By catching the exception, we avoid a 404.
                 Log::warning("The url could not be created because the entry could not be found ({$linkableModel}: {$callToActionBlockData[CallToActionField::FIELD_ENTRY_ID]}). This will probably result in a dead link.");
             }
         }

--- a/src/Filament/Form/Fields/Blocks/Data/CardData.php
+++ b/src/Filament/Form/Fields/Blocks/Data/CardData.php
@@ -47,7 +47,7 @@ class CardData
                 try {
                     $callToActions[] = CallToActionData::create($callToAction, $buttonStyleClasses);
                 } catch (CallToActionNotDefinedException $ex) {
-                    //if the data is not available, we do not create a call to action.
+                    // if the data is not available, we do not create a call to action.
                 }
             }
         }

--- a/src/Filament/Form/Fields/Blocks/Type/AbstractType.php
+++ b/src/Filament/Form/Fields/Blocks/Type/AbstractType.php
@@ -259,7 +259,7 @@ abstract class AbstractType
 
     public function getAlias(): string
     {
-        //TODO check if this needs to be changed for projects without morph map.
+        // TODO check if this needs to be changed for projects without morph map.
         return app($this->getModel())->getMorphClass();
     }
 

--- a/src/Filament/Form/Fields/CodeField.php
+++ b/src/Filament/Form/Fields/CodeField.php
@@ -15,7 +15,7 @@ class CodeField extends TextInput
             ->label(trans('filament-flexible-content-blocks::filament-flexible-content-blocks.form_component.code_lbl'))
             ->helperText(trans('filament-flexible-content-blocks::filament-flexible-content-blocks.form_component.code_help'))
             ->maxLength(255)
-            //disable the field once the code is set, to avoid it breaks the implementation.
+            // disable the field once the code is set, to avoid it breaks the implementation.
             ->disabled(fn (?Model $record) => $record && ! empty($record->code))
             ->required($required);
     }

--- a/src/Filament/Form/Fields/ContentBlocksField.php
+++ b/src/Filament/Form/Fields/ContentBlocksField.php
@@ -12,7 +12,7 @@ class ContentBlocksField extends Builder
 {
     const FIELD = 'content_blocks';
 
-    //cache of instantiated blocks:
+    // cache of instantiated blocks:
     protected ?array $contentBlocks;
 
     public static function create(): static
@@ -22,12 +22,12 @@ class ContentBlocksField extends Builder
             ->addActionLabel(trans('filament-flexible-content-blocks::filament-flexible-content-blocks.form_component.content_blocks_add_lbl'))
             ->addBetweenActionLabel(trans('filament-flexible-content-blocks::filament-flexible-content-blocks.form_component.content_blocks_add_lbl'))
             ->blocks(function (Livewire $livewire, ContentBlocksField $component) {
-                //this function is called very often, therefore we cache the results here.
-                //caching on model level causes weird behaviour with livewire entangle because the block components are not refreshed each time the builder is recreated.
+                // this function is called very often, therefore we cache the results here.
+                // caching on model level causes weird behaviour with livewire entangle because the block components are not refreshed each time the builder is recreated.
                 if (! isset($component->contentBlocks)) {
                     /** @var Page $livewire */
-                    //to set the blocks, filament uses the childComponents.
-                    //set the blocks based on the list of block classes configured on the resource.
+                    // to set the blocks, filament uses the childComponents.
+                    // set the blocks based on the list of block classes configured on the resource.
                     $resource = $livewire::getResource();
 
                     $component->contentBlocks = array_values($resource::getModel()::getFilamentContentBlocks());
@@ -47,7 +47,7 @@ class ContentBlocksField extends Builder
     {
         return collect($this->getState())
             ->filter(function ($itemData): bool {
-                //extra condition to make sure $itemData has a type:
+                // extra condition to make sure $itemData has a type:
                 return is_array($itemData) && array_key_exists('type', $itemData) && $this->hasBlock($itemData['type']);
             })
             ->map(

--- a/src/Filament/Form/Fields/ParentField.php
+++ b/src/Filament/Form/Fields/ParentField.php
@@ -7,7 +7,7 @@ use Statikbe\FilamentFlexibleContentBlocks\Models\Contracts\HasPageAttributes;
 
 class ParentField extends Select
 {
-    const FIELD = 'parent';
+    const FIELD = 'parent_id';
 
     public static function create(): static
     {
@@ -17,6 +17,7 @@ class ParentField extends Select
             ->relationship(name: 'parent', titleAttribute: null)
             ->getOptionLabelFromRecordUsing(fn (HasPageAttributes $record) => $record->title)
             ->searchable(['title', 'intro'])
+            ->preload()
             ->required(false);
     }
 }

--- a/src/Filament/Form/Fields/SlugField.php
+++ b/src/Filament/Form/Fields/SlugField.php
@@ -36,9 +36,9 @@ class SlugField extends TextInput
 
                 return Str::after($url, static::URL_REPLACEMENT_SLUG);
             })
-            //make the slug required on edit. on create, the slug is not required so if kept blank a slug is generated.
+            // make the slug required on edit. on create, the slug is not required so if kept blank a slug is generated.
             ->required(fn (?Model $record): bool => $record && $record->id > 0)
-            //hide slug field on creation, because the spatie sluggable will overwrite it anyways:
+            // hide slug field on creation, because the spatie sluggable will overwrite it anyways:
             ->hidden(function (?Model $record, Page $livewire, Get $get, Set $set): bool {
                 if (empty($record)) {
                     return true;
@@ -49,7 +49,7 @@ class SlugField extends TextInput
                         $locale = $livewire->getActiveFormsLocale();
 
                         $noSlug = empty($record->getTranslation(static::FIELD, $locale, false));
-                        //update translated slug in form:
+                        // update translated slug in form:
                         if (! $noSlug && empty($get(self::FIELD))) {
                             $set(self::FIELD, $record->getTranslation(static::FIELD, $locale, false));
                         }

--- a/src/Filament/Pages/EditRecord/Concerns/TranslatableWithMedia.php
+++ b/src/Filament/Pages/EditRecord/Concerns/TranslatableWithMedia.php
@@ -37,7 +37,7 @@ trait TranslatableWithMedia
                 ->unique()
                 ->all();
 
-            //CHANGE
+            // CHANGE
             $this->form->fill([
                 ...$this->data,
                 ...$localeData,
@@ -55,8 +55,8 @@ trait TranslatableWithMedia
                 throw $exception;
             }
 
-            //$dehydratedLocaleData = $this->form->dehydrateState($localeData);
-            //CHANGE:
+            // $dehydratedLocaleData = $this->form->dehydrateState($localeData);
+            // CHANGE:
             $localeData = Arr::only($this->form->getState(), array_keys($localeData));
 
             $localeData = $this->mutateFormDataBeforeSave($localeData);

--- a/src/FilamentFlexibleBlocksConfig.php
+++ b/src/FilamentFlexibleBlocksConfig.php
@@ -83,12 +83,12 @@ class FilamentFlexibleBlocksConfig
         return Cache::rememberForever('filament-flexible-content-blocks::link_routes', function () {
             /* @var RouteCollection $routeCollection */
             $routeCollection = app()->get('router')->getRoutes()->getRoutes();
-            //Default remove all routes with parameters and no GET requests:
+            // Default remove all routes with parameters and no GET requests:
             $filteredRoutes = collect($routeCollection)->filter(function (Route $route) {
                 return collect($route->methods())->contains('GET') && empty($route->parameterNames());
             });
 
-            //keep routes that match the allowed route parameters:
+            // keep routes that match the allowed route parameters:
             $allowedRoutePatterns = config('filament-flexible-content-blocks.link_routes.allowed');
             if (! empty($allowedRoutePatterns)) {
                 $filteredRoutes = $filteredRoutes->filter(function (Route $route) use ($allowedRoutePatterns) {
@@ -96,7 +96,7 @@ class FilamentFlexibleBlocksConfig
                 });
             }
 
-            //remove routes that match the allowed route parameters:
+            // remove routes that match the allowed route parameters:
             $disallowedRoutePatterns = config('filament-flexible-content-blocks.link_routes.denied');
             if (! empty($disallowedRoutePatterns)) {
                 $filteredRoutes = $filteredRoutes->filter(function (Route $route) use ($disallowedRoutePatterns) {
@@ -174,9 +174,9 @@ class FilamentFlexibleBlocksConfig
             return $configuredConversion($conversion);
         }
 
-        //handle array configuration:
+        // handle array configuration:
         $alreadyDoneConversions = [];
-        //specific cases for specific method calls on the conversion object:
+        // specific cases for specific method calls on the conversion object:
         if (isset($configuredConversion['fit']) && isset($configuredConversion['width']) && isset($configuredConversion['height'])) {
             $conversion->fit($configuredConversion['fit'], $configuredConversion['width'], $configuredConversion['height']);
             $alreadyDoneConversions = ['fit', 'width', 'height'];
@@ -202,7 +202,7 @@ class FilamentFlexibleBlocksConfig
             $conversion->queued();
             $alreadyDoneConversions[] = 'queued';
         }
-        //do the manipulations that are left:
+        // do the manipulations that are left:
         foreach ($configuredConversion as $operation => $value) {
             if (! in_array($operation, $alreadyDoneConversions)) {
                 $conversion->{$operation}($value);

--- a/src/FilamentFlexibleContentBlocks.php
+++ b/src/FilamentFlexibleContentBlocks.php
@@ -43,7 +43,7 @@ class FilamentFlexibleContentBlocks
             return $content;
         }
 
-        //the code below is based on the Illuminate\Translation\Translator->makeReplacements implementation:
+        // the code below is based on the Illuminate\Translation\Translator->makeReplacements implementation:
         $shouldReplace = [];
 
         foreach (static::getReplacerParameters() as $key => $value) {

--- a/src/Models/Concerns/HasContentBlocksTrait.php
+++ b/src/Models/Concerns/HasContentBlocksTrait.php
@@ -14,7 +14,7 @@ trait HasContentBlocksTrait
 {
     public function initializeHasContentBlocksTrait(): void
     {
-        //set casts of attributes:
+        // set casts of attributes:
         $this->mergeCasts([
             'content_blocks' => 'array',
         ]);

--- a/src/Models/Concerns/HasHeroImageAttributesTrait.php
+++ b/src/Models/Concerns/HasHeroImageAttributesTrait.php
@@ -41,10 +41,10 @@ trait HasHeroImageAttributesTrait
                 FilamentFlexibleBlocksConfig::mergeConfiguredModelImageConversion(static::class, $this->getHeroImageCollection(), $this->getHeroImageConversionName(), $conversion);
                 FilamentFlexibleBlocksConfig::addExtraModelImageConversions(static::class, $this->getHeroImageCollection(), $this);
 
-                //for filament upload field
+                // for filament upload field
                 $this->addFilamentThumbnailMediaConversion();
 
-                //add extra conversion for overview image format, when the hero is used as fallback for the overview image:
+                // add extra conversion for overview image format, when the hero is used as fallback for the overview image:
                 if (method_exists($this, 'overviewImage')) {
                     $overviewConversion = $this->addMediaConversion($this->getOverviewImageConversionName())
                         ->withResponsiveImages()
@@ -53,7 +53,7 @@ trait HasHeroImageAttributesTrait
                     FilamentFlexibleBlocksConfig::mergeConfiguredModelImageConversion(static::class, $this->getHeroImageCollection(), $this->getOverviewImageConversionName(), $overviewConversion);
                 }
 
-                //add extra conversion for SEO image format, when the hero is used as fallback for the SEO image:
+                // add extra conversion for SEO image format, when the hero is used as fallback for the SEO image:
                 if (method_exists($this, 'heroImage')) {
                     $seoConversion = $this->addMediaConversion($this->getSEOImageConversionName())
                         ->fit(Fit::Crop, 1200, 630)

--- a/src/Models/Concerns/HasOverviewAttributesTrait.php
+++ b/src/Models/Concerns/HasOverviewAttributesTrait.php
@@ -63,7 +63,7 @@ trait HasOverviewAttributesTrait
                 FilamentFlexibleBlocksConfig::mergeConfiguredModelImageConversion(static::class, $this->getOverviewImageCollection(), $this->getOverviewImageConversionName(), $conversion);
                 FilamentFlexibleBlocksConfig::addExtraModelImageConversions(static::class, $this->getOverviewImageCollection(), $this);
 
-                //for filament upload field
+                // for filament upload field
                 $this->addFilamentThumbnailMediaConversion();
             });
     }

--- a/src/Models/Concerns/HasPageAttributesTrait.php
+++ b/src/Models/Concerns/HasPageAttributesTrait.php
@@ -17,7 +17,7 @@ trait HasPageAttributesTrait
     {
         $this->mergeFillable(['title', 'publishing_begins_at', 'publishing_ends_at']);
 
-        //set casts of attributes:
+        // set casts of attributes:
         $this->mergeCasts([
             'publishing_begins_at' => 'datetime',
             'publishing_ends_at' => 'datetime',
@@ -84,7 +84,7 @@ trait HasPageAttributesTrait
      */
     public function scopePublished(Builder $query): Builder
     {
-        //we need to cover each situation where publishing_begins_at and publishing_ends_at are null:
+        // we need to cover each situation where publishing_begins_at and publishing_ends_at are null:
         return $query->where(function (Builder $publishedQuery) {
             $this->createPublishedSubquery($publishedQuery);
         });
@@ -95,7 +95,7 @@ trait HasPageAttributesTrait
      */
     public function scopeUnpublished(Builder $query): Builder
     {
-        //we need to cover each situation where publishing_begins_at and publishing_ends_at are null:
+        // we need to cover each situation where publishing_begins_at and publishing_ends_at are null:
         return $query->whereNot(function (Builder $publishedQuery) {
             $this->createPublishedSubquery($publishedQuery);
         });

--- a/src/Models/Concerns/HasParentTrait.php
+++ b/src/Models/Concerns/HasParentTrait.php
@@ -13,6 +13,11 @@ use Statikbe\FilamentFlexibleContentBlocks\Models\Contracts\HasParent;
  */
 trait HasParentTrait
 {
+
+    public function initializeHasParentTrait(): void
+    {
+        $this->mergeFillable(['parent_id']);
+    }
     public function parent(): BelongsTo
     {
         return $this->belongsTo(static::class, 'parent_id');

--- a/src/Models/Concerns/HasParentTrait.php
+++ b/src/Models/Concerns/HasParentTrait.php
@@ -13,11 +13,11 @@ use Statikbe\FilamentFlexibleContentBlocks\Models\Contracts\HasParent;
  */
 trait HasParentTrait
 {
-
     public function initializeHasParentTrait(): void
     {
         $this->mergeFillable(['parent_id']);
     }
+
     public function parent(): BelongsTo
     {
         return $this->belongsTo(static::class, 'parent_id');

--- a/src/Models/Concerns/HasSEOAttributesTrait.php
+++ b/src/Models/Concerns/HasSEOAttributesTrait.php
@@ -63,7 +63,7 @@ trait HasSEOAttributesTrait
                 FilamentFlexibleBlocksConfig::mergeConfiguredModelImageConversion(static::class, $this->getSEOImageCollection(), $this->getSEOImageConversionName(), $conversion);
                 FilamentFlexibleBlocksConfig::addExtraModelImageConversions(static::class, $this->getSEOImageCollection(), $this);
 
-                //for filament upload field
+                // for filament upload field
                 $this->addFilamentThumbnailMediaConversion();
             });
     }

--- a/src/Models/Concerns/HasSlugAttributeTrait.php
+++ b/src/Models/Concerns/HasSlugAttributeTrait.php
@@ -20,7 +20,7 @@ trait HasSlugAttributeTrait
 
     protected static function bootHasSlugAttributeTrait(): void
     {
-        //dispatch event when slug changes for published models:
+        // dispatch event when slug changes for published models:
         static::updating(function (self $record) {
             $newSlug = $record->slug;
             $existingSlug = $record->getOriginal('slug');
@@ -39,7 +39,7 @@ trait HasSlugAttributeTrait
                     $published = $record->isPublishedForDates($record->getOriginal('publishing_begins_at'), $record->getOriginal('publishing_ends_at'));
                 }
 
-                //dispatch event:
+                // dispatch event:
                 SlugChanged::dispatch($record, $changedSlugs, $published);
             }
         });

--- a/src/Models/Concerns/HasTranslatedMediaTrait.php
+++ b/src/Models/Concerns/HasTranslatedMediaTrait.php
@@ -54,7 +54,7 @@ trait HasTranslatedMediaTrait
             return [$item->collection_name => $item->uuid];
         })
             ->mapWithKeys(function ($item, string $key) {
-                //make sure the uuids are also available as key. the keys are used to delete unused media files.
+                // make sure the uuids are also available as key. the keys are used to delete unused media files.
                 return [$key => $item->combine($item)];
             })
             ->toArray();

--- a/src/Models/Concerns/HasTranslatedSlugAttributeTrait.php
+++ b/src/Models/Concerns/HasTranslatedSlugAttributeTrait.php
@@ -27,7 +27,7 @@ trait HasTranslatedSlugAttributeTrait
 
     protected static function bootHasTranslatedSlugAttributeTrait(): void
     {
-        //dispatch event when slug changes for published models:
+        // dispatch event when slug changes for published models:
         static::updating(function (self $record) {
             $newSlugs = $record->getTranslations('slug');
             $existingSlugs = $record->getOriginal('slug');
@@ -60,7 +60,7 @@ trait HasTranslatedSlugAttributeTrait
                     $published = $record->isPublishedForDates($record->getOriginal('publishing_begins_at'), $record->getOriginal('publishing_ends_at'));
                 }
 
-                //dispatch event:
+                // dispatch event:
                 SlugChanged::dispatch($record, $changedSlugs, $published);
             }
         });

--- a/src/View/Components/Card.php
+++ b/src/View/Components/Card.php
@@ -61,7 +61,7 @@ class Card extends Component
     {
         $themePrefix = FilamentFlexibleBlocksConfig::getViewThemePrefix();
 
-        //get another template if the block style is set:
+        // get another template if the block style is set:
         $templateSuffix = '';
         if ($this->card->blockStyle && ! empty(trim($this->card->blockStyle))) {
             $templateSuffix = '-'.$this->card->blockStyle;


### PR DESCRIPTION
### Description

When adding a parent on a page, the relation wouldn't save

### Reason for this change

The field name for a relationship should be the same as the foreign key
In this case parent_id instead of parent.