### PR TITLE
ensuring all options selectable in the "content-blocks select list

### DIFF
--- a/config/filament-flexible-content-blocks.php
+++ b/config/filament-flexible-content-blocks.php
@@ -390,6 +390,10 @@ return [
         '[&>ul]:space-y-6',
         '[&>ul>li]:bg-gray-50 [&>ul>li>.fi-fo-builder-item-header]:bg-gray-100',
         '[&>ul>li>.fi-fo-builder-item-header]:rounded-t-xl [&>ul>li.fi-collapsed>.fi-fo-builder-item-header]:rounded-b-xl',
+        /* The class below ensures that all options of the "content-blocks select list" (when
+         | adding a content-block) are always visible. Needed as in some cases, a negative top value
+         | resulted in the top option(s) to be outside the viewport */
+        '[&_.fi-fo-builder-block-picker_.fi-dropdown-panel]:!top-[unset]',
     ],
 
     /*


### PR DESCRIPTION
ensuring that all options of the "content-blocks select list" (in the dropdown when adding a content-block) are always visible. Needed as in some cases, a negative top value resulted in the top option(s) to be outside the viewport