### PR TITLE
Update ContentBlocks.php

### DIFF
--- a/src/View/Components/ContentBlocks.php
+++ b/src/View/Components/ContentBlocks.php
@@ -30,7 +30,7 @@ class ContentBlocks extends Component
         $blockClassIndex = collect($blockClasses)->mapWithKeys(fn ($item, $key) => [$item::getName() => $item]);
         $blocks = [];
 
-        if (isset($page->content_blocks)) {
+        if (! empty($page->content_blocks)) {
             foreach ($page->content_blocks as $blockData) {
                 if (isset($blockData['type']) && $blockClassIndex->has($blockData['type'])) {
                     $blockClass = $blockClassIndex->get($blockData['type']);


### PR DESCRIPTION
### Description

When no content blocks are defined $page->content_blocks is a string. 
This does not play wel with the foreach that follows.

### Reason for this change

Changed the isset() check to ! empty() to get rid of the error and get normal render of the page without the content locks.