### PR TITLE
fix: copy rich editor content as html, not tiptap json

### DIFF
--- a/src/Filament/Actions/CopyContentBlocksToLocalesActionHandler.php
+++ b/src/Filament/Actions/CopyContentBlocksToLocalesActionHandler.php
@@ -126,21 +126,23 @@ class CopyContentBlocksToLocalesActionHandler
     }
 
     /**
-     * The form-level copy action reads raw form state, which for `RichEditor` fields is a
-     * TipTap document array, not the rendered HTML. Persisting that array as-is would store
-     * `{"type":"doc",...}` in the translated `content_blocks` slot, so we dehydrate it here.
+     * The form-level copy action reads raw form state. For `RichEditor` fields under Filament v4
+     * that state is a TipTap document array (`{"type":"doc","content":[...]}`), so we detect it
+     * by shape and dehydrate to HTML before persisting into other locales.
+     *
+     * @todo Remove this sniff once the form-level action dehydrates schema state up front
+     *       (same path as the page-level action, which receives already-HTML state).
      */
     private function isTipTapDocument(array $value): bool
     {
-        return ($value['type'] ?? null) === 'doc' && is_array($value['content'] ?? null);
+        return ($value['type'] ?? null) === 'doc'
+            && is_array($value['content'] ?? null)
+            && array_is_list($value['content']);
     }
 
     private function convertTipTapDocumentToHtml(array $document): string
     {
-        return RichContentRenderer::make()
-            ->getEditor()
-            ->setContent($document)
-            ->getHtml();
+        return RichContentRenderer::make($document)->toHtml();
     }
 
     private function copyImage(Model&HasMedia $record, Media $oldMediaItem, ?string $blockId): string

--- a/src/Filament/Actions/CopyContentBlocksToLocalesActionHandler.php
+++ b/src/Filament/Actions/CopyContentBlocksToLocalesActionHandler.php
@@ -3,6 +3,7 @@
 namespace Statikbe\FilamentFlexibleContentBlocks\Filament\Actions;
 
 use Exception;
+use Filament\Forms\Components\RichEditor\RichContentRenderer;
 use Filament\Notifications\Notification;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
@@ -112,12 +113,34 @@ class CopyContentBlocksToLocalesActionHandler
 
             foreach ($dataBlock as $var => $data) {
                 if (is_array($data)) {
-                    $dataBlock[$var] = $this->convertBlockIdAndCopyImagesToBlock($record, $data);
+                    if ($this->isTipTapDocument($data)) {
+                        $dataBlock[$var] = $this->convertTipTapDocumentToHtml($data);
+                    } else {
+                        $dataBlock[$var] = $this->convertBlockIdAndCopyImagesToBlock($record, $data);
+                    }
                 }
             }
         }
 
         return $contentBlock;
+    }
+
+    /**
+     * The form-level copy action reads raw form state, which for `RichEditor` fields is a
+     * TipTap document array, not the rendered HTML. Persisting that array as-is would store
+     * `{"type":"doc",...}` in the translated `content_blocks` slot, so we dehydrate it here.
+     */
+    private function isTipTapDocument(array $value): bool
+    {
+        return ($value['type'] ?? null) === 'doc' && is_array($value['content'] ?? null);
+    }
+
+    private function convertTipTapDocumentToHtml(array $document): string
+    {
+        return RichContentRenderer::make()
+            ->getEditor()
+            ->setContent($document)
+            ->getHtml();
     }
 
     private function copyImage(Model&HasMedia $record, Media $oldMediaItem, ?string $blockId): string

--- a/tests/Feature/CopyContentBlocksToLocalesTest.php
+++ b/tests/Feature/CopyContentBlocksToLocalesTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Filament\Actions\Testing\TestAction;
 use Illuminate\Http\UploadedFile;
 use Livewire\Livewire;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -423,6 +424,62 @@ it('action is hidden when only one locale is available', function () {
 
     // Action should be hidden (we can't directly test visibility, but can verify locales)
     expect(config('filament-flexible-content-blocks.supported_locales'))->toHaveCount(1);
+});
+
+it('copies rich editor content as html, not tiptap json (form variant)', function () {
+    $page = TranslatablePage::factory()->create([
+        'code' => 'richeditor-copy-test',
+        'title' => ['en' => 'Test'],
+        'slug' => ['en' => 'test'],
+        'content_blocks' => [
+            'en' => [
+                [
+                    'type' => 'text-image',
+                    'data' => [
+                        'block_id' => BlockIdField::generateBlockId(),
+                        'title' => 'EN Title',
+                        'text' => '<p>Hello world</p>',
+                    ],
+                ],
+            ],
+            'nl' => [],
+        ],
+    ]);
+
+    $component = Livewire::test(EditTranslatablePage::class, [
+        'record' => $page->getRouteKey(),
+    ]);
+
+    // Simulate the state shape that exists after the RichEditor field hydrates in the browser:
+    // the `text` field becomes a TipTap document (array), not the raw HTML string.
+    $data = $component->get('data');
+    $builderKey = array_key_first($data['content_blocks']);
+    $data['content_blocks'][$builderKey]['data']['text'] = [
+        'type' => 'doc',
+        'content' => [[
+            'type' => 'paragraph',
+            'content' => [[
+                'type' => 'text',
+                'text' => 'Hello world',
+            ]],
+        ]],
+    ];
+    $component->set('data', $data);
+
+    $component->callAction(TestAction::make('copy_content_blocks_to_other_locales')->schemaComponent(true));
+
+    $page->refresh();
+
+    $nlBlocks = $page->getTranslation('content_blocks', 'nl');
+    $nlBlocks = is_string($nlBlocks) ? json_decode($nlBlocks, true) : $nlBlocks;
+
+    expect($nlBlocks)->toHaveCount(1);
+
+    $text = $nlBlocks[0]['data']['text'] ?? null;
+
+    expect($text)
+        ->toBeString('rich editor text should dehydrate to HTML, not be stored as TipTap JSON array')
+        ->and($text)->toContain('Hello world');
 });
 
 it('does not copy blocks from other locales to EN', function () {

--- a/tests/Resources/TranslatablePageResource.php
+++ b/tests/Resources/TranslatablePageResource.php
@@ -13,6 +13,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\TrashedFilter;
 use Filament\Tables\Table;
 use LaraZeus\SpatieTranslatable\Resources\Concerns\Translatable;
+use Statikbe\FilamentFlexibleContentBlocks\Filament\Form\Actions\CopyContentBlocksToLocalesAction;
 use Statikbe\FilamentFlexibleContentBlocks\Filament\Form\Fields\CodeField;
 use Statikbe\FilamentFlexibleContentBlocks\Filament\Form\Fields\ContentBlocksField;
 use Statikbe\FilamentFlexibleContentBlocks\Filament\Form\Fields\IntroField;
@@ -48,6 +49,7 @@ class TranslatablePageResource extends Resource
                             ]),
                         Tab::make('Content')
                             ->schema([
+                                CopyContentBlocksToLocalesAction::create(),
                                 ContentBlocksField::create(),
                             ]),
                     ]),


### PR DESCRIPTION
## Summary

When the form-level "Copy content blocks to other languages" action runs, it reads
the raw form state. For `RichEditor` fields under Filament v4 that state is a TipTap
document array (`{"type":"doc","content":[...]}`), not the rendered HTML. The handler
was persisting that array verbatim into the translated `content_blocks` slot, so
copied locales ended up with TipTap JSON in their rich-text fields instead of HTML.

This adds a `isTipTapDocument()` check and runs the document through
`RichContentRenderer` to dehydrate it back to HTML before persisting.